### PR TITLE
Fixing test failures on linux

### DIFF
--- a/src/pubs/mongodb-pub/tests/mongodb.spec.ts
+++ b/src/pubs/mongodb-pub/tests/mongodb.spec.ts
@@ -13,6 +13,7 @@ import "zone.js";
 
 import * as assert from "assert";
 import * as fs from "fs";
+import * as net from "net";
 import * as path from "path";
 
 enum Mode {
@@ -24,6 +25,10 @@ enum Mode {
 let mode: Mode = Mode.REPLAY;
 
 describe("mongodb", function() {
+    const server = net.createServer();
+
+    before(() => { server.listen({port: 27017}); });
+    after(() => { server.close(); });
 
     it("should fire events when we communicate with a collection, and preserve context", function(done) {
         const traceName = "mongodb.trace.json";

--- a/src/pubs/mysql-pub/tests/mysql.spec.ts
+++ b/src/pubs/mysql-pub/tests/mysql.spec.ts
@@ -13,6 +13,7 @@ import "zone.js";
 
 import * as assert from "assert";
 import * as fs from "fs";
+import * as net from "net";
 import * as path from "path";
 
 enum Mode {
@@ -24,7 +25,11 @@ enum Mode {
 let mode: Mode = Mode.REPLAY;
 
 describe("mysql", function() {
+    const server = net.createServer();
 
+    before(() => { server.listen({port: 3306}); });
+    after(() => { server.close(); });
+    
     it("should fire events when we interact with it, and preserve context", function(done) {
         const traceName = "mysql.trace.json";
         const tracePath = path.join(__dirname, "util", traceName);


### PR DESCRIPTION
On linux the tests would bail out after failing to connect to closed ports
on localhost. With this fix we provide a dummy server so the connection
succeeds.