### PR TITLE
add a prepare script

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+# Helper script to compile/install the packages in the correct order
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $BASEDIR/src/diagnostic-source
+npm install
+popd
+
+for x in `ls $BASEDIR/src/pubs`; do
+    pushd $BASEDIR/src/pubs/$x
+    npm install
+    popd
+done
+
+for x in `ls $BASEDIR/src/subs`; do
+    if [ ! $x == ".gitignore" -a ! $x == "ai-subs" ]
+    then
+        pushd $BASEDIR/src/subs/$x
+        npm install
+        popd
+    fi
+    pushd $BASEDIR/src/subs/ai-subs
+    npm install
+    popd
+done


### PR DESCRIPTION
I need a script which only runs `npm install` and not clean or test, to utilize when building samples. Can we add this? Thanks!