### PR TITLE
Changing publishers to target es5 to support older versions of node

### DIFF
--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-channel-publishers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": ".dist/src/index.js",
   "types": ".dist/src/index.d.ts",
   "scripts": {
@@ -21,6 +21,7 @@
     "redis": "^2.7.1",
     "mysql": "2.13.0",
     "mongodb": "^2.2.25",
+    "q": "1.5.0",
     "zone.js": "^0.8.5"
   },
   "peerDependencies": {

--- a/src/diagnostic-channel-publishers/tests/mysql.spec.ts
+++ b/src/diagnostic-channel-publishers/tests/mysql.spec.ts
@@ -7,6 +7,8 @@ import {makeMysqlConnectionReplayFunction} from "./util/mysql-mock-replay";
 
 import {enable as enableMysql, IMysqlData} from "../src/mysql.pub";
 
+import * as Q from "q";
+
 import "zone.js";
 
 import * as assert from "assert";
@@ -64,7 +66,7 @@ describe("mysql", function() {
         // We need to ensure that once we run out of connections in the pool, context is still preserved
         z1.run(() => {
             for (let i = 0; i < 2; ++i) {
-                promises.push( new Promise((resolve, reject) =>
+                promises.push( new Q.Promise((resolve, reject) =>
                     pool.query("select 1 as solution", function(err, results) {
                         if (err) {
                             reject(err);
@@ -85,7 +87,7 @@ describe("mysql", function() {
         });
         z2.run(() => {
             for (let i = 0; i < 2; ++i) {
-                promises.push( new Promise((resolve, reject) =>
+                promises.push( new Q.Promise((resolve, reject) =>
                     pool.query("select 2 as solution", function(err, results) {
                         if (err) {
                             reject(err);
@@ -106,7 +108,7 @@ describe("mysql", function() {
             }
         });
 
-        Promise.all(promises).then(() => {
+        Q.all(promises).then(() => {
             assert.equal(events.length, 4);
 
             if (mode === Mode.RECORD) {

--- a/src/diagnostic-channel-publishers/tsconfig.json
+++ b/src/diagnostic-channel-publishers/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2015",
+        "target": "es5",
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true


### PR DESCRIPTION
This is needed because AI targets node all the way back to `0.10.X` which doesn't allow `const`, and if we target `es2015` then the generated js includes `const`s.