### PR TITLE
Hooking up travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,6 @@ sudo: required
 language: node_js
 node_js:
 - 6
-services:
-#- docker
-#- mongodb
-# addons:
-#   apt:
-#     sources:
-#     - mongodb-3.2-precise
-#     packages:
-#     - mongodb-org-server
 install:
  - npm install
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 node_js:
 - 6
 services:
-- docker
-- mongodb
+#- docker
+#- mongodb
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ services:
 #     - mongodb-org-server
 install:
  - npm install
- before_script:
-  - sudo /etc/init.d/mysql stop
+before_script:
+ - sudo /etc/init.d/mysql stop
 script:
-- gulp install
-- gulp clean
-- gulp build
-- gulp lint
-- gulp test
+ - gulp install
+ - gulp clean
+ - gulp build
+ - gulp lint
+ - gulp test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ services:
 #     - mongodb-org-server
 install:
  - npm install
+ before_script:
+  - sudo /etc/init.d/mysql stop
 script:
 - gulp install
 - gulp clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
  - gulp lint
  - gulp test
 notifications:
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ node_js:
 services:
 #- docker
 #- mongodb
-addons:
-  apt:
-    sources:
-    - mongodb-3.2-precise
-    packages:
-    - mongodb-org-server
+# addons:
+#   apt:
+#     sources:
+#     - mongodb-3.2-precise
+#     packages:
+#     - mongodb-org-server
 install:
  - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+language: node_js
+node_js:
+- 6
+services:
+- docker
+- mongodb
+addons:
+  apt:
+    sources:
+    - mongodb-3.2-precise
+    packages:
+    - mongodb-org-server
+install:
+ - npm install
+script:
+- gulp install
+- gulp clean
+- gulp build
+- gulp lint
+- gulp test
+notifications:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,8 +7,8 @@ var util = require('util');
 function getDirectories() {
     var dirs = ['./src/diagnostic-channel',
         './src/diagnostic-channel-publishers'];
-        //.concat(getSubscriberDirectories());
-        return dirs;
+    //.concat(getSubscriberDirectories());
+    return dirs;
 }
 
 function getSubscriberDirectories() {
@@ -56,7 +56,12 @@ function runNpmTasks(taskName, dirs, done) {
     done();
 }
 
-gulp.task('install', function (done) {
+gulp.task('link', function () {
+    runNpmTask('link', './src/diagnostic-channel');
+    runNpmTask('link diagnostic-channel', './src/diagnostic-channel');
+});
+
+gulp.task('install', ['link'], function (done) {
     runNpmTasks('install', getDirectories(), done);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,78 @@
+var gulp = require('gulp');
+var fs = require('fs');
+var cp = require('child_process');
+var path = require('path');
+var util = require('util');
+
+function getDirectories() {
+    var dirs = ['./src/diagnostic-channel',
+        './src/diagnostic-channel-publishers'];
+        //.concat(getSubscriberDirectories());
+        return dirs;
+}
+
+function getSubscriberDirectories() {
+    return [
+        './src/subs/bunyan-sub',
+        './src/subs/console-sub',
+        './src/subs/mongodb-sub',
+        './src/subs/mysql-sub',
+        './src/subs/redis-sub'];
+}
+
+/*
+ * Synchronously run an npm task in a single directory.  Return error code of spawned process.
+ */
+function runNpmTask(taskName, directory) {
+
+    console.log(`running ${taskName} in ${directory}`);
+
+    var opts = {
+        cwd: directory,
+        env: process.env,
+        stdio: 'inherit',
+        shell: true
+    };
+
+    args = taskName.split(' ');
+
+    var proc = cp.spawnSync('npm', args, opts);
+
+    if (proc.error) {
+        process.stderr.write(proc.error.toString());
+    }
+
+    return proc.status;
+}
+
+function runNpmTasks(taskName, dirs, done) {
+    for (var i = 0; i < dirs.length; i++) {
+        var rc = runNpmTask(taskName, dirs[i]);
+        if (rc !== 0) {
+            done(util.format('Error.  command %s in directory %s failed with return code %d', taskName, dirs[i], rc));
+            return;
+        }
+    }
+    done();
+}
+
+gulp.task('install', function (done) {
+    runNpmTasks('install', getDirectories(), done);
+});
+
+gulp.task('clean', function (done) {
+    runNpmTasks('run clean', getDirectories(), done);
+});
+
+gulp.task('build', function (done) {
+    runNpmTasks('run build', getDirectories(), done);
+});
+
+gulp.task('test', function (done) {
+    runNpmTasks('run test', getDirectories(), done);
+});
+
+gulp.task('lint', function (done) {
+    runNpmTasks('run lint', getDirectories(), done);
+});
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "node-diagnostic-channel",
+  "version": "1.0.0",
+  "description": "**diagnostic-channel** provides a shared channel for handling instrumentation\r and diagnostic messages in Node.js apps. Instrumentation patchers and module\r authors can publish messages to this channel by calling `channel.publish(...)`,\r and APM providers and other tools can subscribe to those messages by calling\r `channel.subscribe(...)`. Subscribers can transform the original generic message\r as needed in their handlers and relay the message on to storage and monitoring\r systems.",
+  "main": "gulpfile.js",
+  "dependencies": {
+    "gulp": "^3.9.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Microsoft/node-diagnostic-channel.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Microsoft/node-diagnostic-channel/issues"
+  },
+  "homepage": "https://github.com/Microsoft/node-diagnostic-channel#readme"
+}

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -4,10 +4,10 @@
   "main": ".dist/src/index.js",
   "types": ".dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir ./.dist && node copyTestAssets.js",
-    "lint": "tslint -c tslint.json -p tsconfig.json",
+    "build": "node node_modules/typescript/bin/tsc --outDir ./.dist && node copyTestAssets.js",
+    "lint": "node node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json",
     "clean": "rimraf ./.dist",
-    "test": "npm run build && mocha .dist/tests"
+    "test": "node node_modules/mocha/bin/mocha ./.dist/tests/**/*.js"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -7,7 +7,6 @@
     "build": "tsc --outDir ./.dist && node copyTestAssets.js",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "clean": "rimraf ./.dist",
-    "prepublish": "npm run lint && npm run build",
     "test": "npm run build && mocha .dist/tests"
   },
   "devDependencies": {

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -7,7 +7,7 @@
     "build": "node node_modules/typescript/bin/tsc --outDir ./.dist && node copyTestAssets.js",
     "lint": "node node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json",
     "clean": "rimraf ./.dist",
-    "test": "node node_modules/mocha/bin/mocha ./.dist/tests/**/*.js"
+    "test": "node node_modules/mocha/bin/mocha ./.dist/tests/{*.js,**/*.js}"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.12",
-    "diagnostic-channel": "../diagnostic-channel",
+    "diagnostic-channel": "0.1.0",
     "mocha": "^3.2.0",
     "rimraf": "^2.6.1",
     "tslint": "^5.0.0",

--- a/src/diagnostic-channel/channel.ts
+++ b/src/diagnostic-channel/channel.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 import {IModulePatcher, IModulePatchMap, makePatchingRequire} from "./patchRequire";

--- a/src/diagnostic-channel/channel.ts
+++ b/src/diagnostic-channel/channel.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 import {IModulePatcher, IModulePatchMap, makePatchingRequire} from "./patchRequire";

--- a/src/diagnostic-channel/package.json
+++ b/src/diagnostic-channel/package.json
@@ -4,8 +4,8 @@
   "main": "./.dist/channel.js",
   "types": "./.dist/channel.d.ts",
   "scripts": {
-    "build": "node node_modules/typescript/bin/tsc --outDir ./.dist",
-    "lint": "node node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json",
+    "build": "tsc --outDir ./.dist",
+    "lint": "tslint -c tslint.json -p tsconfig.json",
     "clean": "rimraf ./.dist",
     "test": "node node_modules/mocha/bin/mocha ./.dist/tests/**/*.js"
   },

--- a/src/diagnostic-channel/package.json
+++ b/src/diagnostic-channel/package.json
@@ -7,7 +7,6 @@
     "build": "tsc --outDir ./.dist",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "clean": "rimraf ./.dist",
-    "prepublish": "npm run lint && npm run build",
     "test": "npm run build && mocha ./.dist/tests/**/*.js"
   },
   "dependencies": {

--- a/src/diagnostic-channel/package.json
+++ b/src/diagnostic-channel/package.json
@@ -4,10 +4,10 @@
   "main": "./.dist/channel.js",
   "types": "./.dist/channel.d.ts",
   "scripts": {
-    "build": "tsc --outDir ./.dist",
-    "lint": "tslint -c tslint.json -p tsconfig.json",
+    "build": "node node_modules/typescript/bin/tsc --outDir ./.dist",
+    "lint": "node node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json",
     "clean": "rimraf ./.dist",
-    "test": "npm run build && mocha ./.dist/tests/**/*.js"
+    "test": "node node_modules/mocha/bin/mocha ./.dist/tests/**/*.js"
   },
   "dependencies": {
     "semver": "^5.3.0"


### PR DESCRIPTION
- moved the root-level logic for install/clean/build/lint/test into a gulpfile that can recurse into as many different directories as needed.
- hooks up .travis.yml config to call these gulp tasks
- install.sh/install.cmd are still here. 
- "subs" directories aren't hooked up yet because their build fails.  If the subs stuff can be deleted (not sure why it is here... is it just examples? ), then maybe we can do away with the gulpfile.


