### PR TITLE
Rename output folder to `dist` instead of `.dist`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ package-lock.json
 .node_repl_history
 
 # Compiled typescript
-.dist
+dist
 *.js
 *.js.map
 *.d.ts

--- a/src/diagnostic-channel-publishers/copyTestAssets.js
+++ b/src/diagnostic-channel-publishers/copyTestAssets.js
@@ -4,7 +4,7 @@ var fs = require("fs");
 var path = require("path");
 
 var sourcePath = path.join(__dirname, "tests", "util");
-var destPath = path.join(__dirname, ".dist", "tests", "util");
+var destPath = path.join(__dirname, "dist", "tests", "util");
 
 fs.readdir(sourcePath, (err, files) => {
     if (err) {

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -1,13 +1,13 @@
 {
   "name": "diagnostic-channel-publishers",
   "version": "0.1.3",
-  "main": ".dist/src/index.js",
-  "types": ".dist/src/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc && node copyTestAssets.js",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "clean": "rimraf ./.dist",
-    "test": "mocha ./.dist/tests/{*.js,**/*.js}"
+    "clean": "rimraf ./dist",
+    "test": "mocha ./dist/tests/{*.js,**/*.js}"
   },
   "homepage": "https://github.com/Microsoft/node-diagnostic-channel",
   "bugs": {
@@ -38,8 +38,8 @@
     "diagnostic-channel": "*"
   },
   "files": [
-    ".dist/src/**/*.d.ts",
-    ".dist/src/**/*.js",
+    "dist/src/**/*.d.ts",
+    "dist/src/**/*.js",
     "LICENSE",
     "README.md",
     "package.json"

--- a/src/diagnostic-channel-publishers/src/pg.pub.ts
+++ b/src/diagnostic-channel-publishers/src/pg.pub.ts
@@ -151,7 +151,7 @@ function postgres6PatchFunction(originalPg, originalPgPath) {
 }
 
 export const postgres6: IModulePatcher = {
-    versionSpecifier: ">= 6.0.0 <= 6.4.1",
+    versionSpecifier: "6.x",
     patch: postgres6PatchFunction,
 };
 

--- a/src/diagnostic-channel-publishers/tsconfig.json
+++ b/src/diagnostic-channel-publishers/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "./.dist",
+        "outDir": "./dist",
         "declaration": true
     }
 }

--- a/src/diagnostic-channel/package.json
+++ b/src/diagnostic-channel/package.json
@@ -1,13 +1,13 @@
 {
   "name": "diagnostic-channel",
   "version": "0.1.0",
-  "main": "./.dist/src/channel.js",
-  "types": "./.dist/src/channel.d.ts",
+  "main": "./dist/src/channel.js",
+  "types": "./dist/src/channel.d.ts",
   "scripts": {
     "build": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "clean": "rimraf ./.dist",
-    "test": "mocha ./.dist/tests/**/*.js"
+    "clean": "rimraf ./dist",
+    "test": "mocha ./dist/tests/**/*.js"
   },
   "homepage": "https://github.com/Microsoft/node-diagnostic-channel",
   "bugs": {
@@ -30,8 +30,8 @@
     "typescript": "^2.2.1"
   },
   "files": [
-    ".dist/src/**/*.d.ts",
-    ".dist/src/**/*.js",
+    "dist/src/**/*.d.ts",
+    "dist/src/**/*.js",
     "LICENSE",
     "README.md",
     "package.json"

--- a/src/diagnostic-channel/tsconfig.json
+++ b/src/diagnostic-channel/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "./.dist",
+        "outDir": "./dist",
         "declaration": true
     }
 }


### PR DESCRIPTION
Also updated the pg version specifier to patch all 6.x releases, assuming the internals won't change drastically.