### PR TITLE
Update winston publisher data, minor fixes for 0.2.1

### DIFF
--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-channel-publishers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/src/diagnostic-channel-publishers/src/index.ts
+++ b/src/diagnostic-channel-publishers/src/index.ts
@@ -11,7 +11,7 @@ import * as pg from "./pg.pub";
 import * as redis from "./redis.pub";
 import * as winston from "./winston.pub";
 
-export { bunyan, consolePub as console, mongodbCore, mongodb, mysql, redis, winston};
+export { bunyan, consolePub as console, mongodbCore, mongodb, mysql, redis, winston, pg, pgPool };
 
 export function enable() {
     bunyan.enable();

--- a/src/diagnostic-channel-publishers/src/mongodb-core.pub.ts
+++ b/src/diagnostic-channel-publishers/src/mongodb-core.pub.ts
@@ -35,7 +35,7 @@ const mongodbcorePatchFunction: PatchFunction = function(originalMongoCore) {
 };
 
 export const mongoCore2: IModulePatcher = {
-    versionSpecifier: ">= 2.0.0 <= 2.2.0",
+    versionSpecifier: ">= 2.0.0 < 2.2.0",
     patch: mongodbcorePatchFunction,
 };
 

--- a/src/diagnostic-channel-publishers/tests/winston.spec.ts
+++ b/src/diagnostic-channel-publishers/tests/winston.spec.ts
@@ -6,10 +6,11 @@ import {channel, IStandardEvent, makePatchingRequire} from "diagnostic-channel";
 import {enable as enableWinston, IWinstonData} from "../src/winston.pub";
 
 function compareWinstonData(actual: IWinstonData, expected: IWinstonData): void {
-    assert(actual.message === expected.message, "messages are not equal");
+    assert.strictEqual(actual.message, expected.message, "messages are not equal");
     // meta is an object, but we can always use the same reference
-    assert(actual.meta === expected.meta, "meta objects are not equal");
-    assert(actual.level === expected.level, "levels are not equal");
+    assert.strictEqual(actual.meta, expected.meta, "meta objects are not equal");
+    assert.strictEqual(actual.level, expected.level, "levels are not equal");
+    assert.strictEqual(actual.levelKind, expected.levelKind, "level kinds are not equal");
 }
 
 describe("winston", () => {
@@ -34,14 +35,14 @@ describe("winston", () => {
     });
 
     it("should intercept the default logger", () => {
-        const expected: IWinstonData = {message: "should intercept the default logger", meta: {}, level: "info"};
+        const expected: IWinstonData = {message: "should intercept the default logger", meta: {}, level: "info", levelKind: "npm"};
 
         winston.info(expected.message, expected.meta);
         compareWinstonData(actual, expected);
     });
 
     it("should intercept new loggers", () => {
-        const expected: IWinstonData = {message: "should intercept a new logger", meta: {testing: "new loggers"}, level: "info"};
+        const expected: IWinstonData = {message: "should intercept a new logger", meta: {testing: "new loggers"}, level: "info", levelKind: "npm"};
 
         const loggerWithoutFilter = new winston.Logger({
             transports: [new winston.transports.Console()],
@@ -51,7 +52,7 @@ describe("winston", () => {
     });
 
     it("should intercept loggers with pre-configured filters", () => {
-        const expected: IWinstonData = {message: "unfiltered", meta: {testing: "new loggers"}, level: "info"};
+        const expected: IWinstonData = {message: "unfiltered", meta: {testing: "new loggers"}, level: "info", levelKind: "npm"};
         const filteredMessage = "filtered";
 
         const logger = new winston.Logger({
@@ -66,7 +67,7 @@ describe("winston", () => {
     });
 
     it("should always publish the most-filtered, most-rewritten message", () => {
-        const expected: IWinstonData = {message: "unfiltered", meta: {rewritten: 0}, level: "info"};
+        const expected: IWinstonData = {message: "unfiltered", meta: {rewritten: 0}, level: "info", levelKind: "npm"};
 
         const logger = new winston.Logger({
             filters: [
@@ -82,12 +83,43 @@ describe("winston", () => {
         logger.filters.push(() => "more filtered");
         logger.rewriters.push((level, message, meta) => rewritten2);
         logger.log("info", "unfiltered", {});
-        compareWinstonData(actual, {message: "more filtered", meta: rewritten2, level: "info"});
+        compareWinstonData(actual, {message: "more filtered", meta: rewritten2, level: "info", levelKind: "npm"});
 
         const rewritten3 = { rewritten: 3 };
         logger.filters.push(() => "even more filtered");
         logger.rewriters.push((level, message, meta) => rewritten3);
         logger.log("info", "unfiltered", {});
-        compareWinstonData(actual, {message: "even more filtered", meta: rewritten3, level: "info"});
+        compareWinstonData(actual, {message: "even more filtered", meta: rewritten3, level: "info", levelKind: "npm"});
+    });
+
+    it("should track changes to logging levels", () => {
+        const expected: IWinstonData = {message: "should intercept the default logger", meta: {}, level: "info", levelKind: "npm"};
+        const logger = new winston.Logger({
+            transports: [
+                new winston.transports.Console({
+                    name: "default-console",
+                    level: "info",
+                }),
+                new winston.transports.Console({
+                    name: "levels-console",
+                    level: "l2",
+                }),
+            ],
+        });
+
+        logger.info(expected.message, expected.meta);
+        compareWinstonData(actual, expected);
+
+        logger.setLevels(winston.config.syslog.levels);
+        expected.levelKind = "syslog";
+        expected.level = "warning";
+        logger.warning(expected.message, expected.meta);
+        compareWinstonData(actual, expected);
+
+        logger.setLevels({l0: 0, l1: 1, l2: 2, l3: 3});
+        expected.levelKind = "unknown";
+        expected.level = "l2";
+        logger.log("l2", expected.message, expected.meta);
+        compareWinstonData(actual, expected);
     });
 });


### PR DESCRIPTION
This fixes the following issues I found while writing patches for AI:

1. We were not exporting the pg and pgPool patches in index.ts
2. Winston published the level of the log message as a string, but since [Winston allows configurable levels](https://github.com/winstonjs/winston#logging-levels), this string wasn't a great indicator of what AI level the trace should be published as.

Since we already published 0.2.0 in both channel and publishers, this will need to be 0.2.1 for publishers. @mike-kaufman, I know you wanted these versions to be rev'd in sync, so if you think 0.2.1 for channel should be a no-op, I can change that too. I talked to @MSLaguana about it and our initial thought was that patch updates seem reasonable to go out of sync.

cc @AlexBulankou @OsvaldoRosado 
