### PR TITLE
fix pg-pool connect() not working with await keyword

### DIFF
--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -25,7 +25,7 @@
     "diagnostic-channel": "0.2.0",
     "mocha": "^3.2.0",
     "mongodb": "^2.2.25",
-    "mysql": "^2.13.0",
+    "mysql": "~2.14.1",
     "pg": "^6.4.1",
     "q": "1.5.0",
     "redis": "^2.7.1",
@@ -33,7 +33,7 @@
     "tslint": "^5.0.0",
     "typescript": "^2.2.1",
     "winston": "^2.3.1",
-    "zone.js": "0.8.5"
+    "zone.js": "^0.8.5"
   },
   "peerDependencies": {
     "diagnostic-channel": "*"

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.12",
+    "@types/pg": "^7.4.11",
     "diagnostic-channel": "0.2.0",
     "mocha": "^3.2.0",
     "mongodb": "^2.2.25",

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -33,7 +33,7 @@
     "tslint": "^5.0.0",
     "typescript": "^2.2.1",
     "winston": "^2.3.1",
-    "zone.js": "^0.8.5"
+    "zone.js": "0.8.5"
   },
   "peerDependencies": {
     "diagnostic-channel": "*"

--- a/src/diagnostic-channel-publishers/src/pg-pool.pub.ts
+++ b/src/diagnostic-channel-publishers/src/pg-pool.pub.ts
@@ -2,16 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 import {channel, IModulePatcher, PatchFunction} from "diagnostic-channel";
 import {EventEmitter} from "events";
+import * as pg from "pg";
 
 function postgresPool1PatchFunction(originalPgPool) {
     const originalConnect = originalPgPool.prototype.connect;
 
-    originalPgPool.prototype.connect = function connect(callback?: Function): void {
+    originalPgPool.prototype.connect = function connect(callback?: Function): void | Promise<pg.PoolClient> {
         if (callback) {
             arguments[0] = channel.bindToContext(callback);
         }
 
-        originalConnect.apply(this, arguments);
+        return originalConnect.apply(this, arguments);
     };
 
     return originalPgPool;

--- a/src/diagnostic-channel-publishers/tests/pg.spec.ts
+++ b/src/diagnostic-channel-publishers/tests/pg.spec.ts
@@ -132,7 +132,7 @@ describe("pg@6.x", () => {
                     return done(bad);
                 }
 
-                client.query("SELECT $1", ["0"], (e2, r2) => {
+                client.query("SELECT nonexistant", ["0"], (e2, r2) => {
                     done(checkFailure({
                         res: r2,
                         err: e2,
@@ -259,7 +259,7 @@ describe("pg@6.x", () => {
                     throw bad;
                 }
             }).then(() => {
-                return client.query("SELECT $1", ["0"]).then(() => {
+                return client.query("SELECT nonexistant", ["0"]).then(() => {
                     assert.equal(child, Zone.current, "Context was not preserved");
                     throw new Error("bad query was successful");
                 }, (err) => {
@@ -300,7 +300,7 @@ describe("pg@6.x", () => {
                     throw bad;
                 }
             }).then(() => {
-                return client.query({text: "SELECT $1", values: ["0"]}).then(() => {
+                return client.query({text: "SELECT nonexistant", values: ["0"]}).then(() => {
                     assert.equal(child, Zone.current, "Context was not preserved");
                     throw new Error("bad query was successful");
                 }, (err) => {

--- a/src/subs/bunyan-sub/bunyan.sub.ts
+++ b/src/subs/bunyan-sub/bunyan.sub.ts
@@ -6,17 +6,17 @@ import {bunyan} from "diagnostic-channel-publishers";
 
 // Mapping from bunyan levels defined at https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L256
 const bunyanToAILevelMap = {};
-bunyanToAILevelMap[10] = ApplicationInsights.contracts.SeverityLevel.Verbose;
-bunyanToAILevelMap[20] = ApplicationInsights.contracts.SeverityLevel.Verbose;
-bunyanToAILevelMap[30] = ApplicationInsights.contracts.SeverityLevel.Information;
-bunyanToAILevelMap[40] = ApplicationInsights.contracts.SeverityLevel.Warning;
-bunyanToAILevelMap[50] = ApplicationInsights.contracts.SeverityLevel.Error;
-bunyanToAILevelMap[60] = ApplicationInsights.contracts.SeverityLevel.Critical;
+bunyanToAILevelMap[10] = ApplicationInsights.Contracts.SeverityLevel.Verbose;
+bunyanToAILevelMap[20] = ApplicationInsights.Contracts.SeverityLevel.Verbose;
+bunyanToAILevelMap[30] = ApplicationInsights.Contracts.SeverityLevel.Information;
+bunyanToAILevelMap[40] = ApplicationInsights.Contracts.SeverityLevel.Warning;
+bunyanToAILevelMap[50] = ApplicationInsights.Contracts.SeverityLevel.Error;
+bunyanToAILevelMap[60] = ApplicationInsights.Contracts.SeverityLevel.Critical;
 
 export const subscriber = (event: IStandardEvent<bunyan.IBunyanData>) => {
-    if (ApplicationInsights.client) {
+    if (ApplicationInsights.defaultClient) {
         const AIlevel = bunyanToAILevelMap[event.data.level];
-        ApplicationInsights.client.trackTrace(event.data.result, AIlevel);
+        ApplicationInsights.defaultClient.trackTrace({message: event.data.result, severity: AIlevel});
     }
 };
 

--- a/src/subs/console-sub/console.sub.ts
+++ b/src/subs/console-sub/console.sub.ts
@@ -7,11 +7,11 @@ import {channel, IStandardEvent} from "diagnostic-channel";
 import {console as consolePub} from "diagnostic-channel-publishers";
 
 export const subscriber = (event: IStandardEvent<consolePub.IConsoleData>) => {
-    if (ApplicationInsights.client) {
+    if (ApplicationInsights.defaultClient) {
         const severity = event.data.stderr
-            ? ApplicationInsights.contracts.SeverityLevel.Warning
-            : ApplicationInsights.contracts.SeverityLevel.Information;
-        ApplicationInsights.client.trackTrace(event.data.message, severity);
+            ? ApplicationInsights.Contracts.SeverityLevel.Warning
+            : ApplicationInsights.Contracts.SeverityLevel.Information;
+        ApplicationInsights.defaultClient.trackTrace({message: event.data.message, severity: severity});
     }
 };
 

--- a/src/subs/mongodb-sub/mongodb.sub.ts
+++ b/src/subs/mongodb-sub/mongodb.sub.ts
@@ -17,8 +17,7 @@ export const subscriber = (event: IStandardEvent<mongodb.IMongoData>) => {
                 success: event.data.succeeded,
                 // TODO: transmit result code from mongo
                 resultCode: event.data.succeeded ? "0" : "1",
-                dependencyTypeName: "mongodb"
-            });
+                dependencyTypeName: "mongodb"});
 
         if (!event.data.succeeded) {
             ApplicationInsights.defaultClient

--- a/src/subs/mongodb-sub/mongodb.sub.ts
+++ b/src/subs/mongodb-sub/mongodb.sub.ts
@@ -6,19 +6,23 @@ import {channel, IStandardEvent} from "diagnostic-channel";
 import {mongodb} from "diagnostic-channel-publishers";
 
 export const subscriber = (event: IStandardEvent<mongodb.IMongoData>) => {
-    if (ApplicationInsights.client) {
+    if (ApplicationInsights.defaultClient) {
         const dbName = (event.data.startedData && event.data.startedData.databaseName) || "Unknown database";
-        ApplicationInsights.client
-            .trackDependency(
-                dbName,
-                event.data.event.commandName,
-                event.data.event.duration,
-                event.data.succeeded,
-                "mongodb");
+        ApplicationInsights.defaultClient
+            .trackDependency({
+                target: dbName,
+                name: event.data.event.commandName,
+                data: event.data.event.commandName,
+                duration: event.data.event.duration,
+                success: event.data.succeeded,
+                // TODO: transmit result code from mongo
+                resultCode: event.data.succeeded ? "0" : "1",
+                dependencyTypeName: "mongodb"
+            });
 
         if (!event.data.succeeded) {
-            ApplicationInsights.client
-                .trackException(new Error(event.data.event.failure));
+            ApplicationInsights.defaultClient
+                .trackException({exception: new Error(event.data.event.failure)});
         }
     }
 };

--- a/src/subs/redis-sub/redis.sub.ts
+++ b/src/subs/redis-sub/redis.sub.ts
@@ -6,17 +6,20 @@ import {channel, IStandardEvent} from "diagnostic-channel";
 import {redis} from "diagnostic-channel-publishers";
 
 export const subscriber = (event: IStandardEvent<redis.IRedisData>) => {
-    if (ApplicationInsights.client) {
+    if (ApplicationInsights.defaultClient) {
         if (event.data.commandObj.command === "redis") {
             // We don't want to report 'info', it's irrelevant
             return;
         }
-        ApplicationInsights.client.trackDependency(
-            event.data.address,
-            event.data.commandObj.command,
-            event.data.duration,
-            !event.data.err,
-            "redis");
+
+        ApplicationInsights.defaultClient.trackDependency({
+            target: event.data.address,
+            name: event.data.commandObj.command,
+            data: event.data.commandObj.command,
+            duration: event.data.duration,
+            success: !event.data.err,
+            resultCode: event.data.err ? "1" : "0",
+            dependencyTypeName: "redis"});
     }
 };
 


### PR DESCRIPTION
Fixes #44, https://github.com/Microsoft/ApplicationInsights-node.js/issues/412
- add return to patch so that `var client = await pool.connect()` works properly
- fixes mysql tests failing due to some change in `mysql` from `2.14.1` --> `2.15.0`
- fixes pg tests failing (perhaps) due to some change in `postgreSQL` that allows `SELECT $1` to now be considered a valid query
- update all `trackDependency`, `trackTrace`, etc. calls to use latest Application Insights APIs