### PR TITLE
refactor winston Symbol and meta usage

### DIFF
--- a/src/diagnostic-channel-publishers/src/winston.pub.ts
+++ b/src/diagnostic-channel-publishers/src/winston.pub.ts
@@ -70,14 +70,14 @@ const winston3PatchFunction: PatchFunction = (originalWinston) => {
 
             const levelKind = mapLevelToKind(this.winston, level);
 
-            meta = meta || {};
+            meta = meta || {}; // Winston _somtimes_ puts metadata inside meta, so start from here
             for (const key in splat) {
                 if (splat.hasOwnProperty(key)) {
                     meta[key] = splat[key];
                 }
             }
 
-            channel.publish<IWinstonData>("winston", {  message, level, levelKind, meta });
+            channel.publish<IWinstonData>("winston", { message, level, levelKind, meta });
             callback();
         }
     }

--- a/src/diagnostic-channel-publishers/tests/winston.spec.ts
+++ b/src/diagnostic-channel-publishers/tests/winston.spec.ts
@@ -117,6 +117,22 @@ describe("winston", () => {
         compareWinstonData(actual, {message: "even more filtered", meta: {rewritten: 3}, level: "info", levelKind: "npm"});
     });
 
+    it ("should track correct metadata for child loggers", () => {
+        const expected: IWinstonData = { message: "test message", level: "error", levelKind: "npm", meta: { some: "meta field", another: "metafield" } };
+        const logger = new winston.createLogger({
+            transports: [
+                new winston.transports.Console()
+            ],
+        });
+
+        const childLogger = logger.child({
+            some: "meta field",
+        });
+        childLogger.error("test message", { another: "metafield" });
+
+        compareWinstonData(actual, expected);
+    });
+
     it("should track different syslog logging levels", () => {
         const expected: IWinstonData = {message: "should intercept the default logger", meta: {}, level: "info", levelKind: "npm"};
         const logger = new winston.createLogger({

--- a/src/diagnostic-channel-publishers/tests/winston.spec.ts
+++ b/src/diagnostic-channel-publishers/tests/winston.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 import * as assert from "assert";
-import {channel, IStandardEvent, makePatchingRequire} from "diagnostic-channel";
+import {channel, IStandardEvent } from "diagnostic-channel";
 
 import {enable as enableWinston, IWinstonData} from "../src/winston.pub";
 
@@ -121,7 +121,7 @@ describe("winston", () => {
         const expected: IWinstonData = { message: "test message", level: "error", levelKind: "npm", meta: { some: "meta field", another: "metafield" } };
         const logger = new winston.createLogger({
             transports: [
-                new winston.transports.Console()
+                new winston.transports.Console(),
             ],
         });
 
@@ -130,6 +130,19 @@ describe("winston", () => {
         });
         childLogger.error("test message", { another: "metafield" });
 
+        compareWinstonData(actual, expected);
+    });
+
+    it("should get correct levelKind even if colorized", () => {
+        const expected: IWinstonData = { message: "test message", level: "error", levelKind: "npm", meta: {} };
+        const logger = new winston.createLogger({
+            format: winston.format.combine(winston.format.colorize()),
+            transports: [
+                new winston.transports.Console(),
+            ],
+        });
+
+        logger.error("test message");
         compareWinstonData(actual, expected);
     });
 


### PR DESCRIPTION
Addresses #57 and https://github.com/microsoft/ApplicationInsights-node.js/issues/515
- Read level from `Symbol(level)` since this does not get "colorized"
- Read meta from `...splat` and `meta` instead of `Symbol(meta)` since child loggers do not currently write to this