### PR TITLE
merge mongocore patches with mongo for 3.3+

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ function getDirectories() {
         './src/publisher-legacy-tests/winston2',
         './src/publisher-legacy-tests/mongo2',
         './src/publisher-legacy-tests/mongo3.0.5',
+        './src/publisher-legacy-tests/mongo3.2.7',
         './src/publisher-legacy-tests/pg6'
     ];
 }
@@ -68,6 +69,7 @@ gulp.task('install-main', function () {
     runNpmTask('install', './src/publisher-legacy-tests/winston2');
     runNpmTask('install', './src/publisher-legacy-tests/mongo2');
     runNpmTask('install', './src/publisher-legacy-tests/mongo3.0.5');
+    runNpmTask('install', './src/publisher-legacy-tests/mongo3.2.7');
     runNpmTask('install', './src/publisher-legacy-tests/pg6');
 });
 

--- a/src/diagnostic-channel-publishers/src/mongodb.pub.ts
+++ b/src/diagnostic-channel-publishers/src/mongodb.pub.ts
@@ -96,16 +96,98 @@ const mongodb3PatchFunction: PatchFunction = function(originalMongo) {
     return originalMongo;
 };
 
+// In mongodb 3.3.0, mongodb-core was merged into mongodb, so the same patching
+// can be used here. this.s.pool was changed to this.s.coreTopology.s.pool
+const mongodbcorePatchFunction = function(originalMongo) {
+    const originalConnect = originalMongo.Server.prototype.connect;
+    originalMongo.Server.prototype.connect = function contextPreservingConnect() {
+        const ret = originalConnect.apply(this, arguments);
+
+        // Messages sent to mongo progress through a pool
+        // This can result in context getting mixed between different responses
+        // so we wrap the callbacks to restore appropriate state
+        const originalWrite = this.s.coreTopology.s.pool.write;
+        this.s.coreTopology.s.pool.write = function contextPreservingWrite() {
+            const cbidx = typeof arguments[1] === "function" ? 1 : 2;
+            if (typeof arguments[cbidx] === "function" ) {
+                arguments[cbidx] = channel.bindToContext(arguments[cbidx]);
+            }
+            return originalWrite.apply(this, arguments);
+        };
+
+        // Logout is a special case, it doesn't call the write function but instead
+        // directly calls into connection.write
+        const originalLogout = this.s.coreTopology.s.pool.logout;
+        this.s.coreTopology.s.pool.logout = function contextPreservingLogout() {
+            if (typeof arguments[1] === "function") {
+                arguments[1] = channel.bindToContext(arguments[1]);
+            }
+            return originalLogout.apply(this, arguments);
+        };
+        return ret;
+    };
+
+    return originalMongo;
+};
+
+const mongodb330PatchFunction: PatchFunction = function(originalMongo) {
+    mongodbcorePatchFunction(originalMongo); // apply mongodb-core patches
+    const listener = originalMongo.instrument();
+    const eventMap = {};
+    const contextMap = {};
+    listener.on("started", function(event) {
+        if (eventMap[event.requestId]) {
+            // Note: Mongo can generate 2 completely separate requests
+            // which share the same requestId, if a certain race condition is triggered.
+            // For now, we accept that this can happen and potentially miss or mislabel some events.
+            return;
+        }
+        contextMap[event.requestId] = channel.bindToContext((cb) => cb());
+        eventMap[event.requestId] = event;
+    });
+
+    listener.on("succeeded", function(event) {
+        const startedData = eventMap[event.requestId];
+        if (startedData) {
+            delete eventMap[event.requestId];
+        }
+
+        if (typeof event === "object" && typeof contextMap[event.requestId] === "function") {
+            contextMap[event.requestId](() => channel.publish<IMongoData>("mongodb", {startedData, event, succeeded: true}));
+            delete contextMap[event.requestId];
+        }
+    });
+
+    listener.on("failed", function(event) {
+        const startedData = eventMap[event.requestId];
+        if (startedData) {
+            delete eventMap[event.requestId];
+        }
+
+        if (typeof event === "object" && typeof contextMap[event.requestId] === "function") {
+            contextMap[event.requestId](() => channel.publish<IMongoData>("mongodb", {startedData, event, succeeded: false}));
+            delete contextMap[event.requestId];
+        }
+    });
+
+    return originalMongo;
+};
+
 export const mongo2: IModulePatcher = {
     versionSpecifier: ">= 2.0.0 <= 3.0.5",
     patch: mongodbPatchFunction,
 };
 export const mongo3: IModulePatcher = {
-    versionSpecifier: "> 3.0.5 < 4.0.0",
+    versionSpecifier: "> 3.0.5 < 3.3.0",
     patch: mongodb3PatchFunction,
+};
+export const mongo330: IModulePatcher = {
+    versionSpecifier: ">= 3.3.0 < 4.0.0",
+    patch: mongodb330PatchFunction,
 };
 
 export function enable() {
     channel.registerMonkeyPatch("mongodb", mongo2);
     channel.registerMonkeyPatch("mongodb", mongo3);
+    channel.registerMonkeyPatch("mongodb", mongo330);
 }

--- a/src/diagnostic-channel-publishers/tests/mongodb.spec.ts
+++ b/src/diagnostic-channel-publishers/tests/mongodb.spec.ts
@@ -20,7 +20,7 @@ enum Mode {
 /* tslint:disable-next-line:prefer-const */
 let mode: Mode = Mode.REPLAY;
 
-describe("mongodb@3.x", function() {
+describe("mongodb@>3.3", function() {
     before(() => {
         enableCore();
         enableMongo();

--- a/src/publisher-legacy-tests/mongo3.2.7/mongo3.2.7.spec.ts
+++ b/src/publisher-legacy-tests/mongo3.2.7/mongo3.2.7.spec.ts
@@ -20,7 +20,7 @@ enum Mode {
 /* tslint:disable-next-line:prefer-const */
 let mode: Mode = Mode.REPLAY;
 
-describe("mongodb@3.0.5", function() {
+describe("mongodb@3.2.7", function() {
     before(() => {
         enableCore();
         enableMongo();

--- a/src/publisher-legacy-tests/mongo3.2.7/package.json
+++ b/src/publisher-legacy-tests/mongo3.2.7/package.json
@@ -1,0 +1,42 @@
+{
+  "scripts": {
+    "build": "tsc",
+    "lint": "tslint -c tslint.json -p tsconfig.json",
+    "clean": "rimraf ./dist",
+    "test": "mocha --recursive ./dist/{*.js,**/*.js}",
+    "debug": "mocha --inspect-brk ./dist/tests/{*.js,**/*.js}"
+  },
+  "homepage": "https://github.com/Microsoft/node-diagnostic-channel",
+  "bugs": {
+    "url": "https://github.com/Microsoft/node-diagnostic-channel/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/node-diagnostic-channel.git"
+  },
+  "description": "A collection of pre-built module patches that enable existing npm modules to publish diagnostic data",
+  "devDependencies": {
+    "@types/mocha": "^2.2.40",
+    "@types/node": "^7.0.12",
+    "@types/pg": "^7.4.11",
+    "diagnostic-channel": "0.2.0",
+    "mocha": "^3.2.0",
+    "mongodb": "3.2.7",
+    "q": "1.5.0",
+    "rimraf": "^2.6.1",
+    "tslint": "^5.0.0",
+    "typescript": "^2.2.1",
+    "zone.js": "^0.8.5"
+  },
+  "peerDependencies": {
+    "diagnostic-channel": "*"
+  },
+  "files": [
+    "dist/src/**/*.d.ts",
+    "dist/src/**/*.js",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
+  "license": "MIT"
+}

--- a/src/publisher-legacy-tests/mongo3.2.7/tsconfig.json
+++ b/src/publisher-legacy-tests/mongo3.2.7/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist",
+        "declaration": true,
+        "target": "es5",
+        "module": "commonjs",
+        "sourceMap": true
+    }
+}

--- a/src/publisher-legacy-tests/mongo3.2.7/tslint.json
+++ b/src/publisher-legacy-tests/mongo3.2.7/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../../tslint.json"
+}


### PR DESCRIPTION
Mongodb 3.3.0 merged in the functionality of the `mongodb-core` package, so patching that was done there must instead be done in `mongodb` for versions >= `3.3.0`.