### PR TITLE
chore: bump versions for 0.4.0-preview release

### DIFF
--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-channel-publishers",
-  "version": "0.3.3",
+  "version": "0.4.0-preview",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/src/diagnostic-channel/package.json
+++ b/src/diagnostic-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-channel",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "./dist/src/channel.js",
   "types": "./dist/src/channel.d.ts",
   "scripts": {


### PR DESCRIPTION
`diagnostic-channel`: `0.2.0`...`0.3.0`
`diagnostic-channel-publishers`: `0.3.3`...`0.4.0-preview`