### PR TITLE
Update azure core tracing publisher

### DIFF
--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-channel-publishers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
@@ -21,8 +21,8 @@
   "description": "A collection of pre-built module patches that enable existing npm modules to publish diagnostic data",
   "devDependencies": {
     "@azure/core-tracing": "^1.0.0-preview.12",
-    "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/tracing": "^0.23.0",
+    "@opentelemetry/api": "^1.0.2",
+    "@opentelemetry/tracing": "^0.24.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "^8.5.0",
     "@types/pg": "7.4.11",

--- a/src/diagnostic-channel-publishers/package.json
+++ b/src/diagnostic-channel-publishers/package.json
@@ -20,7 +20,7 @@
   },
   "description": "A collection of pre-built module patches that enable existing npm modules to publish diagnostic data",
   "devDependencies": {
-    "@azure/core-tracing": "^1.0.0-preview.12",
+    "@azure/core-tracing": "1.0.0-preview.12",
     "@opentelemetry/api": "^1.0.2",
     "@opentelemetry/tracing": "^0.24.0",
     "@types/mocha": "^8.2.2",

--- a/src/diagnostic-channel-publishers/src/azure-coretracing.pub.ts
+++ b/src/diagnostic-channel-publishers/src/azure-coretracing.pub.ts
@@ -71,10 +71,10 @@ const azureCoreTracingPatchFunction: PatchFunction = (coreTracing: typeof coreTr
                     tracer[AzureMonitorSymbol] = true;
                     return tracer;
                 };
-                return setGlobalTracerProviderOriginal.call(tracerProvider);
+                return setGlobalTracerProviderOriginal.call(this, tracerProvider);
             };
+            defaultProvider.register();
             api.trace.getSpan(api.context.active()); // seed OpenTelemetryScopeManagerWrapper with "active" symbol
-            api.trace.setGlobalTracerProvider(defaultProvider);
         }
 
         isPatched = true;

--- a/src/diagnostic-channel-publishers/src/azure-coretracing.pub.ts
+++ b/src/diagnostic-channel-publishers/src/azure-coretracing.pub.ts
@@ -26,31 +26,59 @@ const azureCoreTracingPatchFunction: PatchFunction = (coreTracing: typeof coreTr
     try {
         const tracing = require("@opentelemetry/tracing") as typeof tracingTypes;
         const api = require("@opentelemetry/api") as typeof opentelemetryTypes;
-        const provider = new tracing.BasicTracerProvider();
-        const defaultTracer = provider.getTracer("applicationinsights tracer");
+        const defaultProvider = new tracing.BasicTracerProvider();
+        const defaultTracer = defaultProvider.getTracer("applicationinsights tracer");
 
-        // Patch Azure SDK setTracer
-        const setTracerOriginal = coreTracing.setTracer;
-
-        coreTracing.setTracer = function(tracer: any) {
-            // Patch startSpan instead of using spanProcessor.onStart because parentSpan must be
-            // set while the span is constructed
-            const startSpanOriginal = tracer.startSpan;
-            tracer.startSpan = function(name: string, options?: opentelemetryTypes.SpanOptions, context?: opentelemetryTypes.Context) {
-                const span = startSpanOriginal.call(this, name, options, context);
-                const originalEnd = span.end;
-                span.end = function() {
-                    const result = originalEnd.apply(this, arguments);
-                    channel.publish("azure-coretracing", span);
-                    return result;
+        // Patch Azure SDK setTracer, @azure/core-tracing <= 1.0.0-preview.12
+        if (coreTracing.setTracer) {
+            const setTracerOriginal = coreTracing.setTracer;
+            coreTracing.setTracer = function (tracer: any) {
+                // Patch startSpan instead of using spanProcessor.onStart because parentSpan must be
+                // set while the span is constructed
+                const startSpanOriginal = tracer.startSpan;
+                tracer.startSpan = function (name: string, options?: opentelemetryTypes.SpanOptions, context?: opentelemetryTypes.Context) {
+                    const span = startSpanOriginal.call(this, name, options, context);
+                    const originalEnd = span.end;
+                    span.end = function () {
+                        const result = originalEnd.apply(this, arguments);
+                        channel.publish("azure-coretracing", span);
+                        return result;
+                    };
+                    return span;
                 };
-                return span;
+                tracer[AzureMonitorSymbol] = true;
+                setTracerOriginal.call(this, tracer);
             };
-            tracer[AzureMonitorSymbol] = true;
-            setTracerOriginal.call(this, tracer);
-        };
-        api.trace.getSpan(api.context.active()); // seed OpenTelemetryScopeManagerWrapper with "active" symbol
-        coreTracing.setTracer(defaultTracer);
+            api.trace.getSpan(api.context.active()); // seed OpenTelemetryScopeManagerWrapper with "active" symbol
+            coreTracing.setTracer(defaultTracer);
+        }
+        // Patch OpenTelemetry setGlobalTracerProvider  @azure/core-tracing > 1.0.0-preview.13
+        else {
+            const setGlobalTracerProviderOriginal = api.trace.setGlobalTracerProvider;
+            api.trace.setGlobalTracerProvider = function (tracerProvider: opentelemetryTypes.TracerProvider) {
+                const getTracerOriginal = tracerProvider.getTracer;
+                tracerProvider.getTracer = function (name, version) {
+                    let tracer = getTracerOriginal.call(this, name, version);
+                    const startSpanOriginal = tracer.startSpan;
+                    tracer.startSpan = function (name: string, options?: opentelemetryTypes.SpanOptions, context?: opentelemetryTypes.Context) {
+                        const span = startSpanOriginal.call(this, name, options, context);
+                        const originalEnd = span.end;
+                        span.end = function () {
+                            const result = originalEnd.apply(this, arguments);
+                            channel.publish("azure-coretracing", span);
+                            return result;
+                        };
+                        return span;
+                    };
+                    tracer[AzureMonitorSymbol] = true;
+                    return tracer;
+                }
+                return setGlobalTracerProviderOriginal.call(tracerProvider);
+            };
+            api.trace.getSpan(api.context.active()); // seed OpenTelemetryScopeManagerWrapper with "active" symbol
+            api.trace.setGlobalTracerProvider(defaultProvider);
+        }
+
         isPatched = true;
     } catch (e) { /* squash errors */ }
     return coreTracing;

--- a/src/diagnostic-channel-publishers/tsconfig.json
+++ b/src/diagnostic-channel-publishers/tsconfig.json
@@ -3,12 +3,6 @@
     "compilerOptions": {
         "outDir": "./dist",
         "declaration": true,
-        "baseUrl": ".",
-        "paths": {
-            "@opentelemetry/tracing": [".sink.d.ts"],
-            "@opentelemetry/api": [".sink.d.ts"],
-            "@azure/core-tracing": [".sink.d.ts"],
-            "*": ["*"]
-        }
+        "baseUrl": "."
     }
 }


### PR DESCRIPTION
Use global tracer provider for newer versions of @azure/core-tracing